### PR TITLE
Swagger: Remove date time regex from Swagger documentation

### DIFF
--- a/src/main/java/ch/admin/bag/covidcertificate/gateway/service/dto/incoming/CovidCertificatePersonDto.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/gateway/service/dto/incoming/CovidCertificatePersonDto.java
@@ -11,6 +11,6 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class CovidCertificatePersonDto {
     private CovidCertificatePersonNameDto name;
-    @Schema(example= "1950-06-04", description = "birthdate of the covid certificate owner. Format: ISO 8601 date without time. Range: can be between 1900-01-01 and 2099-12-31. Regexp: \"[19|20][0-9][0-9]-(0[1-9]|1[0-2])-([0-2][1-9]|3[0|1])\".")
+    @Schema(example= "1950-06-04", description = "birthdate of the covid certificate owner. Format: ISO 8601 date without time. Range: can be between 1900-01-01 and 2099-12-31.")
     private LocalDate dateOfBirth;
 }

--- a/src/main/java/ch/admin/bag/covidcertificate/gateway/service/dto/incoming/RecoveryCertificateDataDto.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/gateway/service/dto/incoming/RecoveryCertificateDataDto.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class RecoveryCertificateDataDto {
-    @Schema(example = "2021-10-03", description = "date when the sample for the test was collected that led to positive test obtained through a procedure established by a public health authority. Format: ISO 8601 date without time. Range: can be between 1900-01-01 and 2099-12-31. Regexp: \"[19|20][0-9][0-9]-(0[1-9]|1[0-2])-([0-2][1-9]|3[0|1])\".")
+    @Schema(example = "2021-10-03", description = "date when the sample for the test was collected that led to positive test obtained through a procedure established by a public health authority. Format: ISO 8601 date without time. Range: can be between 1900-01-01 and 2099-12-31.")
     private LocalDate dateOfFirstPositiveTestResult;
     @Schema(example = "CH", description = "the country in which the covid certificate owner has been tested. Format: string (2 chars according to ISO 3166 Country Codes).")
     private String countryOfTest;

--- a/src/main/java/ch/admin/bag/covidcertificate/gateway/service/dto/incoming/VaccinationCertificateDataDto.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/gateway/service/dto/incoming/VaccinationCertificateDataDto.java
@@ -16,7 +16,7 @@ public class VaccinationCertificateDataDto {
     private Integer numberOfDoses;
     @Schema(example= "2", description = "total series of doses.")
     private Integer totalNumberOfDoses;
-    @Schema(example= "2021-05-14", description = "date of vaccination. Format: ISO 8601 date without time. Range: can be between 1900-01-01 and 2099-12-31. Regexp: \"[19|20][0-9][0-9]-(0[1-9]|1[0-2])-([0-2][1-9]|3[0|1])\".")
+    @Schema(example= "2021-05-14", description = "date of vaccination. Format: ISO 8601 date without time. Range: can be between 1900-01-01 and 2099-12-31.")
     private LocalDate vaccinationDate;
     @Schema(example= "CH", description = "the country in which the covid certificate owner has been vaccinated. Format: string (2 chars according to ISO 3166 Country Codes).")
     private String countryOfVaccination;


### PR DESCRIPTION
These are already defined by ISO 8601.
https://github.com/admin-ch/CovidCertificate-Apidoc/issues/4