### PR TITLE
Validate zipCode and updated ErrorHandler

### DIFF
--- a/src/main/java/ch/admin/bag/covidcertificate/gateway/service/dto/incoming/CovidCertificateAddressDto.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/gateway/service/dto/incoming/CovidCertificateAddressDto.java
@@ -8,11 +8,11 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class CovidCertificateAddressDto {
-    @Schema(required = true, description = "Street and number of the certificate holder.", example = "Musterweg 4b")
+    @Schema(required = true, description = "Street and number of the certificate holder.", example = "Musterweg 4b", maxLength = 128, minLength = 1)
     private String streetAndNr;
     @Schema(required = true, example = "3000", maxLength = 4, minLength = 4, type = "integer")
     private int zipCode;
-    @Schema(required = true, example = "Bern")
+    @Schema(required = true, example = "Bern", maxLength = 128, minLength = 1)
     private String city;
     @Schema(required = true, description = "Abbreviation of the canton issuing the certificate. " +
             "This will be used as the sender of the paper based delivery.", example = "BE"

--- a/src/main/java/ch/admin/bag/covidcertificate/gateway/service/dto/incoming/CovidCertificateAddressDto.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/gateway/service/dto/incoming/CovidCertificateAddressDto.java
@@ -11,7 +11,7 @@ public class CovidCertificateAddressDto {
     @Schema(required = true, description = "Street and number of the certificate holder.", example = "Musterweg 4b")
     private String streetAndNr;
     @Schema(required = true, example = "3000", maxLength = 4, minLength = 4, type = "integer")
-    private String zipCode;
+    private int zipCode;
     @Schema(required = true, example = "Bern")
     private String city;
     @Schema(required = true, description = "Abbreviation of the canton issuing the certificate. " +

--- a/src/main/java/ch/admin/bag/covidcertificate/gateway/web/controller/ResponseStatusExceptionHandler.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/gateway/web/controller/ResponseStatusExceptionHandler.java
@@ -4,11 +4,13 @@ import ch.admin.bag.covidcertificate.gateway.error.RestError;
 import ch.admin.bag.covidcertificate.gateway.service.InvalidBearerTokenException;
 import ch.admin.bag.covidcertificate.gateway.service.dto.CreateCertificateException;
 import ch.admin.bag.covidcertificate.gateway.service.dto.RevokeCertificateException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.core.NestedRuntimeException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -55,25 +57,26 @@ public class ResponseStatusExceptionHandler {
         return handleError(ex.getError());
     }
 
+    @ExceptionHandler(value = {HttpMessageNotReadableException.class})
+    protected ResponseEntity<RestError> notReadableRequestPayload(HttpMessageNotReadableException ex) {
+        RestError error;
+        try {
+            var rootException = (InvalidFormatException)ex.getCause();
+            assert rootException != null;
+            var errorMessage = "Unable to parse " + rootException.getValue() + " to " + rootException.getTargetType();
+            log.warn("HttpMessage with invalid format received: ", rootException);
+            error = new RestError(HttpStatus.BAD_REQUEST.value(), errorMessage, HttpStatus.BAD_REQUEST);
+        } catch (ClassCastException | AssertionError processingException) {
+            log.warn("HttpMessage is not readable: ", ex);
+            error = new RestError(HttpStatus.BAD_REQUEST.value(), "Http message not readable", HttpStatus.BAD_REQUEST);
+        }
+        return handleError(error);
+    }
+
     @ExceptionHandler(value = {Exception.class})
     protected ResponseEntity<Object> handleException(Exception e) {
         log.error("Exception during processing", e);
         return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-    }
-
-    @ExceptionHandler(value = {HttpMessageNotReadableException.class})
-    protected ResponseEntity<RestError> notReadableRequestPayload(HttpMessageNotReadableException ex) {
-        var errorMessage = getRootCauseMessage(ex);
-        var error = new RestError(HttpStatus.BAD_REQUEST.value(), errorMessage, HttpStatus.BAD_REQUEST);
-        return handleError(error);
-    }
-
-    private String getRootCauseMessage(NestedRuntimeException ex){
-        return Stream.of(ex.getRootCause(), ex.getCause(), ex)
-                .filter(Objects::nonNull)
-                .findFirst()
-                .map(Throwable::getMessage)
-                .orElse("");
     }
     
     private ResponseEntity<RestError> handleError(RestError restError) {

--- a/src/test/java/ch/admin/bag/covidcertificate/gateway/web/controller/ResponseStatusExceptionHandlerTest.java
+++ b/src/test/java/ch/admin/bag/covidcertificate/gateway/web/controller/ResponseStatusExceptionHandlerTest.java
@@ -1,0 +1,117 @@
+package ch.admin.bag.covidcertificate.gateway.web.controller;
+
+import ch.admin.bag.covidcertificate.gateway.error.RestError;
+import ch.admin.bag.covidcertificate.gateway.service.InvalidBearerTokenException;
+import ch.admin.bag.covidcertificate.gateway.service.dto.CreateCertificateException;
+import ch.admin.bag.covidcertificate.gateway.service.dto.RevokeCertificateException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.flextrade.jfixture.JFixture;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ResponseStatusExceptionHandlerTest {
+    private final JFixture fixture = new JFixture();
+
+    private TestResponseStatusExceptionHandlerWrapper testExceptionHanlder = new TestResponseStatusExceptionHandlerWrapper();
+
+    @Test
+    public void createCertificateConflictReturnsRestError__withCreateCertificateException() {
+        var exception = mock(CreateCertificateException.class);
+        var restError = new RestError(400, "test", HttpStatus.BAD_REQUEST);
+        when(exception.getError()).thenReturn(restError);
+
+        var responseEntity = this.testExceptionHanlder.createCertificateConflict(exception);
+        assertEquals(restError.getErrorCode(), Objects.requireNonNull(responseEntity.getBody()).getErrorCode());
+        assertEquals(restError.getErrorMessage(), Objects.requireNonNull(responseEntity.getBody()).getErrorMessage());
+        assertEquals(restError.getHttpStatus(), Objects.requireNonNull(responseEntity.getStatusCode()));
+    }
+
+    @Test
+    public void createCertificateConflictReturnsRestError__withRevokeCertificateException() {
+        var exception = mock(RevokeCertificateException.class);
+        var restError = new RestError(400, "test", HttpStatus.BAD_REQUEST);
+        when(exception.getError()).thenReturn(restError);
+
+        var responseEntity = this.testExceptionHanlder.createCertificateConflict(exception);
+        assertEquals(restError.getErrorCode(), Objects.requireNonNull(responseEntity.getBody()).getErrorCode());
+        assertEquals(restError.getErrorMessage(), Objects.requireNonNull(responseEntity.getBody()).getErrorMessage());
+        assertEquals(restError.getHttpStatus(), Objects.requireNonNull(responseEntity.getStatusCode()));
+    }
+
+    @Test
+    public void invalidBearerReturnsRestError() {
+        var exception = mock(InvalidBearerTokenException.class);
+        var restError = new RestError(492, "test", HttpStatus.FORBIDDEN);
+        when(exception.getError()).thenReturn(restError);
+
+        var responseEntity = this.testExceptionHanlder.invalidBearer(exception);
+        assertEquals(restError.getErrorCode(), Objects.requireNonNull(responseEntity.getBody()).getErrorCode());
+        assertEquals(restError.getErrorMessage(), Objects.requireNonNull(responseEntity.getBody()).getErrorMessage());
+        assertEquals(restError.getHttpStatus(), Objects.requireNonNull(responseEntity.getStatusCode()));
+    }
+
+    @Test
+    public void notReadableHandlerReturnsInvalidValueMessage__ifInvalidFormatException() {
+        final var testValue = "--VALUE--";
+        var exception = mock(HttpMessageNotReadableException.class);
+        var causedByException = new InvalidFormatException(mock(JsonParser.class), "", testValue, String.class);
+        when(exception.getCause()).thenReturn(causedByException);
+
+        var responseEntity = this.testExceptionHanlder.notReadableRequestPayload(exception);
+        assertEquals(400, Objects.requireNonNull(responseEntity.getBody()).getErrorCode());
+        var expectedErrorMessage = "Unable to parse " + testValue + " to " + String.class;
+        assertEquals(expectedErrorMessage, responseEntity.getBody().getErrorMessage());
+    }
+
+    @Test
+    public void notReadableHandlerReturnsUnreadableMessage__ifNotInvalidFormatException() {
+        var exception = mock(HttpMessageNotReadableException.class);
+        when(exception.getCause()).thenReturn(new RuntimeException());
+
+        var responseEntity = this.testExceptionHanlder.notReadableRequestPayload(exception);
+        assertEquals(400, Objects.requireNonNull(responseEntity.getBody()).getErrorCode());
+        var expectedErrorMessage = "Http message not readable";
+        assertEquals(expectedErrorMessage, responseEntity.getBody().getErrorMessage());
+    }
+
+    @Test
+    public void returns500__onAnyException() {
+        var exception = mock(Exception.class);
+        var responseEntity = this.testExceptionHanlder.handleException(exception);
+        assertEquals(responseEntity.getStatusCode(),HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private static class TestResponseStatusExceptionHandlerWrapper {
+        private final ResponseStatusExceptionHandler responseStatusExceptionHandler = new ResponseStatusExceptionHandler();
+
+        public ResponseEntity<RestError> createCertificateConflict(CreateCertificateException ex) {
+            return responseStatusExceptionHandler.createCertificateConflict(ex);
+        }
+
+        public ResponseEntity<RestError> createCertificateConflict(RevokeCertificateException ex) {
+            return responseStatusExceptionHandler.createCertificateConflict(ex);
+        }
+
+        public ResponseEntity<RestError> invalidBearer(InvalidBearerTokenException ex) {
+            return responseStatusExceptionHandler.invalidBearer(ex);
+        }
+
+        public ResponseEntity<RestError> notReadableRequestPayload(HttpMessageNotReadableException ex) {
+            return responseStatusExceptionHandler.notReadableRequestPayload(ex);
+        }
+
+        public ResponseEntity<Object> handleException(Exception e) {
+            return responseStatusExceptionHandler.handleException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
- Block requests with invalid zipCode from progressing
- Update ErrorHandler for _HttpMessageNotReadableException_ to prevent exposure of the StackTrace
- Create unit tests for _ResponseStatusExceptionHandler_